### PR TITLE
Add Jest tests for suggestPrompts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/__tests__/suggestPrompts.test.js
+++ b/__tests__/suggestPrompts.test.js
@@ -1,0 +1,37 @@
+const fs = require('fs');
+const vm = require('vm');
+
+function runSuggestPrompts(option) {
+  const textarea = { value: '' };
+  const docMock = {
+    getElementById: jest.fn((id) => {
+      if (id === 'promptSelector') return { value: option };
+      if (id === 'userPrompt') return textarea;
+      return null;
+    }),
+    addEventListener: jest.fn(),
+  };
+  const context = { document: docMock, console, alert: () => {} };
+  vm.createContext(context);
+  const code = fs.readFileSync(require.resolve('../script.js'), 'utf8');
+  vm.runInContext(code, context);
+  context.suggestPrompts();
+  return { value: textarea.value, getElementById: docMock.getElementById };
+}
+
+describe('suggestPrompts', () => {
+  const expectations = {
+    items: `Generate a responsive item grid that shows each item's name, type, and rarity color-coded.\n\nCreate an inventory-style panel with tooltips that appear when hovering over each item.\n\nDisplay each item in a list with a shadowboxed tooltip showing affixes and description.`,
+    player: `Render a stat sheet showing strength, dexterity, vitality, and other attributes.\n\nCreate a character info panel styled like a fantasy RPG with min/max stat bars.\n\nDisplay stats with colored progress bars and labels.`,
+    monsters: `Create a bestiary grid with monster names, types, and elemental weaknesses.\n\nRender monster cards with HP, attack power, and danger level.\n\nShow a battle log-style UI displaying monster encounters.`,
+    inventory: `Design a grid-style inventory bag with locked and unlocked slots.\n\nHighlight equipped items and allow room for expansion buttons.\n\nCreate a UI showing drag-and-drop functionality for sorting gear.`,
+    '': 'Enter a prompt that describes how you want the UI to look based on your uploaded data.'
+  };
+
+  for (const [option, expected] of Object.entries(expectations)) {
+    test(`sets suggestions for ${option || 'default'}`, () => {
+      const result = runSuggestPrompts(option);
+      expect(result.value).toBe(expected);
+    });
+  }
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "game-ui-generator",
+  "version": "1.0.0",
+  "description": "A data-driven, AI-powered UI generator for browser-based RPGs, clickers, and loot games. Build dynamic inventory panels, stat sheets, monster logs, and more — just by uploading a CSV and giving it a prompt.",
+  "main": "script.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.7.0"
+  }
+}


### PR DESCRIPTION
## Summary
- add npm package.json with Jest dev dependency
- mock DOM and test `suggestPrompts` for each dropdown value
- ignore node_modules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fa72eff2c832aa4b313845a01903b